### PR TITLE
[Admission control] Terminology and interface documentation

### DIFF
--- a/admission_control_service/README.md
+++ b/admission_control_service/README.md
@@ -40,3 +40,79 @@ Further details about the functioning of Gatekeeper can be found in the
 | CustomResourceDefinition | Extension of the Kubernetes API not available in default Kubernetes installations |
 | Mutating admission controller | Admission controllers that may modify objects related to the request they admit |
 | Validating admission controller | Admission controllers that may not modify objects related to the request they admit |
+
+## Gatekeeper's custom resources definitions
+
+The following section provides the basic details necessary to understand how to
+interact with the Gatekeeper service. Additional details can be found in the
+[Gatekeeper documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/).
+
+### Constraint Templates
+
+Before defining a constraint, it is necessary to declare its template, which
+describes the Rego policy enforcing the constraint and the schema of its
+parameters.
+
+Here is an example constraint template that requires pods to be downloaded by a
+list of allowed repositories:
+
+```yaml
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sallowedrepos
+  annotations:
+    metadata.gatekeeper.sh/title: "Allowed Repositories"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires container images to begin with a string from the specified list.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAllowedRepos
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            repos:
+              description: The list of prefixes a container image is allowed to have.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sallowedrepos
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          not strings.any_prefix_match(container.image, input.parameters.repos)
+          msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+        }
+```
+
+### Constraint
+
+It enforces a ConstraintTemplate by specificying the kind of resources affected
+and the enforcement parameters. In this example, the constraint uses the
+`K8sAllowedRepos` constraint template above to ensure pods deployed to the
+default namespace come from the `openpolicyagent` image registry.
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAllowedRepos
+metadata:
+  name: repo-is-openpolicyagent
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces:
+      - "default"
+  parameters:
+    repos:
+      - "openpolicyagent/"
+```


### PR DESCRIPTION
Update existing documentation to include `Terminology` and `Gatekeeper's custom resources definitions` sections.